### PR TITLE
Improving the tests around the connection pool and relays.

### DIFF
--- a/extras/loadtest.go
+++ b/extras/loadtest.go
@@ -175,10 +175,10 @@ func generateMetricNames(numMetrics int, store []Metric) []Metric {
 		newMetricName, _ := randutil.String(20, randutil.Alphabet)
 		newMetricNS := fmt.Sprintf("statsgod.test.%s", newMetricName)
 		newMetricCT := 1
-		if *connType > 0 && *connType < 5 {
+		if *connType > 0 && *connType < 6 {
 			newMetricCT = *connType
 		} else {
-			newMetricCT, _ = randutil.IntRange(1, 5)
+			newMetricCT, _ = randutil.IntRange(1, 6)
 		}
 
 		metricType := metricTypes[r.Intn(len(metricTypes))]

--- a/statsgod/connectionpool.go
+++ b/statsgod/connectionpool.go
@@ -111,7 +111,8 @@ func (pool *ConnectionPool) GetConnection(logger Logger) (net.Conn, error) {
 	case <-time.After(pool.Timeout):
 		logger.Error.Println("No connections available.")
 		err := errors.New("Connection timeout.")
-		return nil, err
+		nilConn := NilConn{}
+		return nilConn, err
 	}
 }
 

--- a/statsgod/nilconn.go
+++ b/statsgod/nilconn.go
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2014 Acquia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package statsgod
+
+import (
+	"net"
+	"time"
+)
+
+// NilConnPanicMsg is the message that the NilConn implementation sends in panic.
+const (
+	NilConnPanicMsg = "Use of a nil connection."
+)
+
+// NilConn is an implementation of the net.Conn interface. We use it so that
+// we can return a value from GetConnection. Without the NilConn, it would
+// attempt to convert nil into a net.Conn which causes an error. In this case
+// we can handle it gracefully and panic for any access instead of attemting
+// to access a nil pointer.
+type NilConn struct{}
+
+// Read implements net.Conn.Read()
+func (c NilConn) Read(b []byte) (n int, err error) {
+	panic(NilConnPanicMsg)
+}
+
+// Write implements net.Conn.Write()
+func (c NilConn) Write(b []byte) (n int, err error) {
+	panic(NilConnPanicMsg)
+}
+
+// Close implements net.Conn.Close()
+func (c NilConn) Close() error {
+	panic(NilConnPanicMsg)
+}
+
+// LocalAddr implements net.Conn.LocalAddr()
+func (c NilConn) LocalAddr() net.Addr {
+	panic(NilConnPanicMsg)
+}
+
+// RemoteAddr implements net.Conn.RemoteAddr()
+func (c NilConn) RemoteAddr() net.Addr {
+	panic(NilConnPanicMsg)
+}
+
+// SetDeadline implements net.Conn.SetDeadline()
+func (c NilConn) SetDeadline(t time.Time) error {
+	panic(NilConnPanicMsg)
+}
+
+// SetReadDeadline implements net.Conn.SetReadDeadline()
+func (c NilConn) SetReadDeadline(t time.Time) error {
+	panic(NilConnPanicMsg)
+}
+
+// SetWriteDeadline implements net.Conn.SetWriteDeadline()
+func (c NilConn) SetWriteDeadline(t time.Time) error {
+	panic(NilConnPanicMsg)
+}

--- a/statsgod/nillconn_test.go
+++ b/statsgod/nillconn_test.go
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2014 Acquia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package statsgod_test
+
+import (
+	. "github.com/acquia/statsgod/statsgod"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+var _ = Describe("NilConn", func() {
+
+	Describe("Testing the basic structure", func() {
+		Context("when creating a NilConn", func() {
+			It("should be a complete structure", func() {
+				// Test the NilConn implementation.
+				nilConn := NilConn{}
+				nilBuf := make([]byte, 0)
+				nilTime := time.Now()
+				Expect(func() { nilConn.Read(nilBuf) }).Should(Panic())
+				Expect(func() { nilConn.Write(nilBuf) }).Should(Panic())
+				Expect(func() { nilConn.Close() }).Should(Panic())
+				Expect(func() { nilConn.LocalAddr() }).Should(Panic())
+				Expect(func() { nilConn.RemoteAddr() }).Should(Panic())
+				Expect(func() { nilConn.SetDeadline(nilTime) }).Should(Panic())
+				Expect(func() { nilConn.SetReadDeadline(nilTime) }).Should(Panic())
+				Expect(func() { nilConn.SetWriteDeadline(nilTime) }).Should(Panic())
+			})
+		})
+	})
+})

--- a/statsgod/relay_test.go
+++ b/statsgod/relay_test.go
@@ -79,6 +79,14 @@ var _ = Describe("Relay", func() {
 				backendRelay.Relay(*metricOne, logger)
 				backendRelay.Relay(*metricTwo, logger)
 				backendRelay.Relay(*metricThree, logger)
+
+				// Test a broken relay.
+				StopTemporaryListener()
+
+				Expect(func() { backendRelay.Relay(*metricOne, logger) }).Should(Panic())
+
+				// Restart the broken relay to shutdown properly.
+				tmpPort = StartTemporaryListener()
 			})
 		})
 


### PR DESCRIPTION
This adds tests to verify that we can handle multiple metrics separated by newline characters in TCP and Unix socket connections. It also adds a NilConn struct which is a net.Conn interface implementation. The purpose of this is because when the connection pool times out, it currently returns nil. This is poor because it tries to coerce nil into a net.Conn which causes a nil pointer access error. The new NilConn allows us to return the proper type and panic if client code tries to use it. This is much more graceful and allows us to properly test access to a broken connection.
