### PR TITLE
Use an enum instead of a string for internal metric types.

### DIFF
--- a/extras/log_compare.go
+++ b/extras/log_compare.go
@@ -102,13 +102,13 @@ go run extras/log_compare.go -in=/tmp/statsgod.input -out=/tmp/statsgod.output
 			outputR := outputRegex.FindAllStringSubmatch(outputLines[i], -1)
 			if len(outputR) > 0 && len(outputR[0]) == 4 {
 				switch outputR[0][2] {
-				case "counter":
+				case "0":
 					metricType = "c"
-				case "gauge":
+				case "1":
 					metricType = "g"
-				case "set":
+				case "2":
 					metricType = "s"
-				case "timer":
+				case "3":
 					metricType = "ms"
 				}
 				outputLine = fmt.Sprintf("%s:%s|%s", outputR[0][1], outputR[0][3], metricType)

--- a/statsgod.go
+++ b/statsgod.go
@@ -276,19 +276,19 @@ func prepareRuntimeMetrics(metrics map[string]statsgod.Metric, config statsgod.C
 		// Prepare a metric for the memory allocated.
 		heapAllocKey := fmt.Sprintf("statsgod.%s.runtime.memory.heapalloc", hostname)
 		heapAllocValue := float64(memStats.HeapAlloc) / float64(Megabyte)
-		heapAllocMetric := statsgod.CreateSimpleMetric(heapAllocKey, heapAllocValue, "gauge")
+		heapAllocMetric := statsgod.CreateSimpleMetric(heapAllocKey, heapAllocValue, statsgod.MetricTypeGauge)
 		metrics[heapAllocMetric.Key] = *heapAllocMetric
 
 		// Prepare a metric for the memory allocated that is still in use.
 		allocKey := fmt.Sprintf("statsgod.%s.runtime.memory.alloc", hostname)
 		allocValue := float64(memStats.Alloc) / float64(Megabyte)
-		allocMetric := statsgod.CreateSimpleMetric(allocKey, allocValue, "gauge")
+		allocMetric := statsgod.CreateSimpleMetric(allocKey, allocValue, statsgod.MetricTypeGauge)
 		metrics[allocMetric.Key] = *allocMetric
 
 		// Prepare a metric for the memory obtained from the system.
 		sysKey := fmt.Sprintf("statsgod.%s.runtime.memory.sys", hostname)
 		sysValue := float64(memStats.Sys) / float64(Megabyte)
-		sysMetric := statsgod.CreateSimpleMetric(sysKey, sysValue, "gauge")
+		sysMetric := statsgod.CreateSimpleMetric(sysKey, sysValue, statsgod.MetricTypeGauge)
 		metrics[sysMetric.Key] = *sysMetric
 	}
 }
@@ -299,12 +299,12 @@ func prepareFlushMetrics(metrics map[string]statsgod.Metric, config statsgod.Con
 		// Prepare the duration metric.
 		durationKey := fmt.Sprintf("statsgod.%s.flush.duration", hostname)
 		durationValue := float64(int64(flushStop.Sub(flushStart).Nanoseconds()) / int64(time.Millisecond))
-		durationMetric := statsgod.CreateSimpleMetric(durationKey, durationValue, "timer")
+		durationMetric := statsgod.CreateSimpleMetric(durationKey, durationValue, statsgod.MetricTypeTimer)
 		metrics[durationMetric.Key] = *durationMetric
 
 		// Prepare the counter metric.
 		countKey := fmt.Sprintf("statsgod.%s.flush.count", hostname)
-		countMetric := statsgod.CreateSimpleMetric(countKey, float64(flushCount), "gauge")
+		countMetric := statsgod.CreateSimpleMetric(countKey, float64(flushCount), statsgod.MetricTypeGauge)
 		metrics[countMetric.Key] = *countMetric
 	}
 }

--- a/statsgod/metric_test.go
+++ b/statsgod/metric_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Metrics", func() {
 				Expect(metricOne).ShouldNot(Equal(nil))
 				Expect(metricOne.Key).Should(Equal("test.three"))
 				Expect(metricOne.LastValue).Should(Equal(float64(3)))
-				Expect(metricOne.MetricType).Should(Equal("gauge"))
+				Expect(metricOne.MetricType).Should(Equal(MetricTypeGauge))
 			})
 
 			// Test that incorrect strings trigger errors.
@@ -95,7 +95,7 @@ var _ = Describe("Metrics", func() {
 			It("should create a metric with the correct values", func() {
 				key := "test"
 				value := float64(123)
-				metricType := "gauge"
+				metricType := MetricTypeGauge
 				metric := CreateSimpleMetric(key, value, metricType)
 				Expect(metric.Key).Should(Equal(key))
 				Expect(metric.MetricType).Should(Equal(metricType))

--- a/statsgod/relay.go
+++ b/statsgod/relay.go
@@ -70,19 +70,19 @@ func (c CarbonRelay) Relay(metric Metric, logger Logger) bool {
 	// Ensure all of the metrics are working correctly.
 
 	switch metric.MetricType {
-	case "gauge":
+	case MetricTypeGauge:
 		gkey = fmt.Sprintf("stats.gauges.%s", metric.Key)
 		sendCarbonMetric(gkey, metric.LastValue, stringTime, true, c, logger)
-	case "counter":
+	case MetricTypeCounter:
 		gkey = fmt.Sprintf("stats.rates.%s", metric.Key)
 		sendCarbonMetric(gkey, metric.ValuesPerSecond, stringTime, true, c, logger)
 
 		gkey = fmt.Sprintf("stats.counts.%s", metric.Key)
 		sendCarbonMetric(gkey, metric.LastValue, stringTime, true, c, logger)
-	case "set":
+	case MetricTypeSet:
 		gkey = fmt.Sprintf("stats.sets.%s", metric.Key)
 		sendCarbonMetric(gkey, metric.LastValue, stringTime, true, c, logger)
-	case "timer":
+	case MetricTypeTimer:
 		// Cumulative values.
 		gkey = fmt.Sprintf("stats.timers.%s.mean_value", metric.Key)
 		sendCarbonMetric(gkey, metric.MeanValue, stringTime, true, c, logger)


### PR DESCRIPTION
This will give a nice little performance boost.
