### PR TITLE
Slight change in the order of docker args.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,6 @@ recv:
 	go run -race extras/receiver/test_receiver.go
 
 run-container:
-	docker run -it statsgod -v $(pwd)/:/usr/share/go/src/github.com/acquia/statsgod /bin/bash
+	docker run -v $(shell pwd)/:/usr/share/go/src/github.com/acquia/statsgod -it statsgod /bin/bash
 
 .PHONY: all clean run deps test

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ To download all dependencies and compile statsgod
 To run in a docker container
 
 	docker build -t statsgod .
-	docker run -it statsgod -v $(pwd)/:/usr/share/go/src/github.com/acquia/statsgod /bin/bash -c "make && make deb"
+	docker run -v $(pwd)/:/usr/share/go/src/github.com/acquia/statsgod -it statsgod /bin/bash -c "make && make deb"
 
 ## Testing
 For automated tests we are using http://onsi.github.io/ginkgo/ and http://onsi.github.io/gomega/. We have a combination of unit, integration and benchmark tests which are executed by Travis.ci.


### PR DESCRIPTION
For some reason the order of the flags matters for me. If -v is after the -it it tries to execute "-v" and fails. Also, added a "shell" to the makefile in run-container.
