### PR TITLE
Improving string performance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Data is sent over a socket connection as a string using the format: [namespace]:
 - Timer   (ms): a timer that calculates averages (see below).
 - Set     (s): a count of unique values sent during a flush period.
 
-Optionally you may denote that a metric has been sampled by adding "|@[sample rate as a float]". Counters will inflate the value accordingly so that it can be accurately used to calculate a rate.
+Optionally you may denote that a metric has been sampled by adding "|@0.75" (where 0.75 is the sample rate as a float). Counters will inflate the value accordingly so that it can be accurately used to calculate a rate.
 
 An example data string would be "user.login.success:123|c|@0.9"
 
@@ -44,12 +44,14 @@ Client code can send metrics via any one of three sockets which listen concurren
 	- Allows multiple metrics to be sent over a connection, separated by a newline character.
 	- Connection will remain open until closed by the client.
 	- Config:
+		- connection.udp.enabled
 		- connection.udp.host
 		- connection.udp.port
 
 2. UDP
 	- Allows multiple metrics to be sent over a connection, separated by a newline character. Note, you should be careful to not exceed the maximum packet size (default 1024 bytes).
 	- Config:
+		- connection.udp.enabled
 		- connection.udp.host
 		- connection.udp.port
 		- connection.udp.maxpacket (buffer size to read incoming packets)
@@ -58,6 +60,7 @@ Client code can send metrics via any one of three sockets which listen concurren
 	- Allows multiple metrics to be sent over a connection, separated by a newline character.
 	- Connection will remain open until closed by the client.
 	- Config:
+		- connection.unix.enabled
 		- config: connection.unix.file (path to the sock file)
 
 ## Configuration
@@ -174,42 +177,7 @@ The statsgod service is equipped to handle the following signals:
 - debug.profile
 
 ## Development
-To download all dependencies and compile statsgod
-
-	go get -u github.com/mattn/gom
-	mkdir -p $GOPATH/src/github.com/acquia/statsgod
-	git clone https://github.com/acquia/statsgod $GOPATH/src/github.com/acquia/statsgod
-	cd $GOPATH/src/github.com/acquia/statsgod
-	gom install
-	gom build -o $GOPATH/bin/statsgod
-
-
-To run in a docker container
-
-	docker build -t statsgod .
-	docker run -v $(pwd)/:/usr/share/go/src/github.com/acquia/statsgod -it statsgod /bin/bash -c "make && make deb"
-
-## Testing
-For automated tests we are using http://onsi.github.io/ginkgo/ and http://onsi.github.io/gomega/. We have a combination of unit, integration and benchmark tests which are executed by Travis.ci.
-
-	make test
-
-## Load Testing and QA
-For load testing and manual QA we have a script in /extras/loadtest.go that can be used to soak the system. There are a lot of options with invocation, so take a moment to read through and understand them. The most used flags specify the number of metrics, amount of concurrency and type of connection to test (tcp, tcp with connection pool, udp, unix and unix with connection pool).
-
-Here is an example using the -logSent flag which will emit a line for each metric string sent. For statsgod.go, use the config option config.debug.receipt: true to emit the received/parsed metrics. Using the log\_compare.go utility you can compare each metric sent to each received/parsed metric received to ensure that nothing was lost.
-
-1. Start statsgod.go with config.debug.receipt set to true and redirect to a file:
-
-		gom exec go run statsgod.go 2>&1 /tmp/statsgod.output
-
-2. Start loadtest.go with the -logSent flag and redirect to a file:
-
-		gom exec go run extras/loadtest.go [options] -logSent=true 2>&1 /tmp/statsgod.input
-
-3. After collecting input and output, compare using the log\_compare.go utility:
-
-		gom exec go run extras/log_compare.go -in=/tmp/statsgod.input -out=/tmp/statsgod.output
+[Read more about the development process.](doc/development.md)
 
 ## License
 Except as otherwise noted this software is licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-statsgod (0.1-3) trusty; urgency=low
+statsgod (0.2-1) trusty; urgency=low
 
   * Initial release
 

--- a/debian/statsgod.init
+++ b/debian/statsgod.init
@@ -52,6 +52,8 @@ do_start()
 	mkdir -p $RUN_DIR
 	chown -R $STATSGOD_USER $RUN_DIR
 	chmod 775 $RUN_DIR
+	# Ensure that we can handle the socket traffic.
+	ulimit -n 65000
 	# Return
 	#   0 if daemon has been started
 	#   1 if daemon was already running

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,0 +1,54 @@
+## Development
+To download all dependencies and compile statsgod
+
+	go get -u github.com/mattn/gom
+	mkdir -p $GOPATH/src/github.com/acquia/statsgod
+	git clone https://github.com/acquia/statsgod $GOPATH/src/github.com/acquia/statsgod
+	cd $GOPATH/src/github.com/acquia/statsgod
+	gom install
+	gom build -o $GOPATH/bin/statsgod
+
+
+To run in a docker container
+
+	docker build -t statsgod .
+	docker run -v $(pwd)/:/usr/share/go/src/github.com/acquia/statsgod -it statsgod /bin/bash -c "make && make deb"
+
+## Testing
+For automated tests we are using http://onsi.github.io/ginkgo/ and http://onsi.github.io/gomega/. We have a combination of unit, integration and benchmark tests which are executed by Travis.ci.
+
+	make test
+
+## Load Testing and QA
+For load testing and manual QA we have a script in /extras/loadtest.go that can be used to soak the system. There are a lot of options with invocation, so take a moment to read through and understand them. The most used flags specify the number of metrics, amount of concurrency and type of connection to test (tcp, tcp with connection pool, udp, unix and unix with connection pool).
+
+Here is an example using the -logSent flag which will emit a line for each metric string sent. For statsgod.go, use the config option config.debug.receipt: true to emit the received/parsed metrics. Using the log\_compare.go utility you can compare each metric sent to each received/parsed metric received to ensure that nothing was lost.
+
+1. Start statsgod.go with config.debug.receipt set to true and redirect to a file:
+
+		gom exec go run statsgod.go 2>&1 /tmp/statsgod.output
+
+2. Start loadtest.go with the -logSent flag and redirect to a file:
+
+		gom exec go run extras/loadtest.go [options] -logSent=true 2>&1 /tmp/statsgod.input
+
+3. After collecting input and output, compare using the log\_compare.go utility:
+
+		gom exec go run extras/log_compare.go -in=/tmp/statsgod.input -out=/tmp/statsgod.output
+
+## Profiling
+To profile this program we have been using the runtime.pprof library. Build a binary, start the daemon and run it through a real-world set of tests to fully exercise the code. After the program exits it will create a file in the same directory called "statsgod.prof". This profile, along with the binary, can be used to learn more about the runtime.
+
+Config:
+	debug.profile = true
+
+	gom build -o sg # Build a binary called "sg"
+	./sg -config=/path/to/config # start the daemon and don't forget to set config.debug.profile = true
+	# run some tests and stop the daemon. "sg" is the binary and "statsgod.prof" is the profile.
+	go tool pprof --help # See all of the options.
+	go tool pprof --dot sg statsgod.prof # Generate a dot file for graphviz.
+	go tool pprof --gif sg statsgod.prof # Generate a gif of the visualization.
+	go tool pprof sg statsgod.prof # Interactive mode:
+	(pprof) top30 -cum # View the top 30 functions sorted by cumulative sample counts.
+
+

--- a/example.config.yml
+++ b/example.config.yml
@@ -16,13 +16,16 @@ service:
 ###
 connection:
     tcp:
+        enabled: true
         host: 127.0.0.1
         port: 8125
     udp:
+        enabled: true
         host: 127.0.0.1
         port: 8126
         maxpacket: 1024
     unix:
+        enabled: true
         file: /var/run/statsgod/statsgod.sock
 
 ###

--- a/statsgod/config.go
+++ b/statsgod/config.go
@@ -48,16 +48,19 @@ type ConfigValues struct {
 	}
 	Connection struct {
 		Tcp struct {
-			Host string
-			Port int
+			Enabled bool
+			Host    string
+			Port    int
 		}
 		Udp struct {
+			Enabled   bool
 			Host      string
 			Port      int
 			Maxpacket int
 		}
 		Unix struct {
-			File string
+			Enabled bool
+			File    string
 		}
 	}
 	Relay struct {
@@ -119,11 +122,14 @@ func (config *ConfigValues) LoadFile(filePath string) error {
 	config.Service.Hostname = ""
 
 	// Connection
+	config.Connection.Tcp.Enabled = true
 	config.Connection.Tcp.Host = "127.0.0.1"
 	config.Connection.Tcp.Port = 8125
+	config.Connection.Udp.Enabled = true
 	config.Connection.Udp.Host = "127.0.0.1"
 	config.Connection.Udp.Port = 8126
 	config.Connection.Udp.Maxpacket = 1024
+	config.Connection.Unix.Enabled = true
 	config.Connection.Unix.File = "/var/run/statsgod/statsgod.sock"
 
 	// Relay

--- a/statsgod/config_test.go
+++ b/statsgod/config_test.go
@@ -42,11 +42,14 @@ var _ = Describe("Config", func() {
 				Expect(config.Service.Hostname).ShouldNot(Equal(nil))
 
 				// Connection
+				Expect(config.Connection.Tcp.Enabled).ShouldNot(Equal(nil))
 				Expect(config.Connection.Tcp.Host).ShouldNot(Equal(nil))
 				Expect(config.Connection.Tcp.Port).ShouldNot(Equal(nil))
+				Expect(config.Connection.Udp.Enabled).ShouldNot(Equal(nil))
 				Expect(config.Connection.Udp.Host).ShouldNot(Equal(nil))
 				Expect(config.Connection.Udp.Port).ShouldNot(Equal(nil))
 				Expect(config.Connection.Udp.Maxpacket).ShouldNot(Equal(nil))
+				Expect(config.Connection.Unix.Enabled).ShouldNot(Equal(nil))
 				Expect(config.Connection.Unix.File).ShouldNot(Equal(nil))
 
 				// Relay
@@ -100,11 +103,14 @@ var _ = Describe("Config", func() {
 				Expect(hostname).Should(Equal(config.Service.Hostname))
 
 				// Connection
+				Expect(yaml.Connection.Tcp.Enabled).Should(Equal(config.Connection.Tcp.Enabled))
 				Expect(yaml.Connection.Tcp.Host).Should(Equal(config.Connection.Tcp.Host))
 				Expect(yaml.Connection.Tcp.Port).Should(Equal(config.Connection.Tcp.Port))
+				Expect(yaml.Connection.Udp.Enabled).Should(Equal(config.Connection.Udp.Enabled))
 				Expect(yaml.Connection.Udp.Host).Should(Equal(config.Connection.Udp.Host))
 				Expect(yaml.Connection.Udp.Port).Should(Equal(config.Connection.Udp.Port))
 				Expect(yaml.Connection.Udp.Maxpacket).Should(Equal(config.Connection.Udp.Maxpacket))
+				Expect(yaml.Connection.Unix.Enabled).Should(Equal(config.Connection.Unix.Enabled))
 				Expect(yaml.Connection.Unix.File).Should(Equal(config.Connection.Unix.File))
 
 				// Relay

--- a/statsgod/socket_test.go
+++ b/statsgod/socket_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Sockets", func() {
 						case <-time.After(5 * time.Second):
 							message = ""
 						}
-						Expect(message).Should(Equal(rm))
+						Expect(strings.TrimSpace(message)).Should(Equal(strings.TrimSpace(rm)))
 					}
 				}
 			}


### PR DESCRIPTION
After profiling I noticed that it was spending a ton of time in strings.Trim() so I reworked it a little bit to iterate over the runes (int32 char value) instead of using convenience functions in the strings lib. Subsequent profiling and pidstat monitoring looks much better. There is still a lot of room for improvement, but this is an incremental improvement.
