### PR TITLE
Prevent a panic from trying to call .Close() on a NilConn 

### DIFF
--- a/statsgod/connectionpool.go
+++ b/statsgod/connectionpool.go
@@ -123,7 +123,13 @@ func (pool *ConnectionPool) ReleaseConnection(conn net.Conn, recreate bool, logg
 	// recreate signifies that there was something wrong with the connection and
 	// that we should make a new one.
 	if recreate {
-		conn.Close()
+		switch conn.(type) {
+		case NilConn:
+		// do nothing
+		default:
+			conn.Close()
+		}
+
 		added, err := pool.CreateConnection(logger)
 		if !added || err != nil {
 			logger.Error.Println("Could not release connection.", err)


### PR DESCRIPTION
This causes a panic when carbon is temporarily unavailable.  I got tired of restarting the services everywhere, and I believe this fixes the problem.
