### PR TITLE
Go vet is now bundled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.4
   - 1.5
+  - 1.6
 before_install:
   - sudo apt-get update
   - go get github.com/mattn/gom

--- a/Gomfile
+++ b/Gomfile
@@ -16,14 +16,12 @@
 gom 'github.com/jmcvetta/randutil'
 gom 'gopkg.in/yaml.v2'
 
-# Prior to go 1.4 vet and cover are retrieved from legacy URLs.
+# Prior to go 1.4 cover is retrieved from the legacy URL.
 group :test_legacy do
-  gom 'code.google.com/p/go.tools/cmd/vet'
   gom 'code.google.com/p/go.tools/cmd/cover'
 end
 
 group :test_tip do
-  gom 'golang.org/x/tools/cmd/vet'
   gom 'golang.org/x/tools/cmd/cover'
 end
 

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,12 @@ deps: clean
 	$(GOM) -groups=$(GOM_GROUPS_FLAG) install
 
 lint: deps
-	$(GOM) exec go fmt ./...
-	$(GOM) exec go vet -x ./...
-	$(GOM) exec golint .
+	$(GOM) exec go fmt statsgod.go statsgod_test.go
+	$(GOM) exec go fmt statsgod/*.go
+	$(GOM) exec go vet -x statsgod.go statsgod_test.go
+	$(GOM) exec go vet -x statsgod/*.go
+	$(GOM) exec golint statsgod.go statsgod_test.go
+	$(GOM) exec golint statsgod/*.go
 	$(foreach p, $(PACKAGES), $(GOM) exec golint ./$(p)/.; )
 
 test: deps lint


### PR DESCRIPTION
This PR does three things
- gets rid of the 1.4 travis tests as the version is out of date
- gets rid of the external dependency on vet as it is now part of >1.5
- explicitly vets and lints our files as travis includes other packages that shouldn't fail our tests
